### PR TITLE
Category pages are not paged correctly.

### DIFF
--- a/src/content/posts/dummy-1.md
+++ b/src/content/posts/dummy-1.md
@@ -1,0 +1,23 @@
+---
+title: "My awesome second blog post"
+image: "/images/post/post-3.jpg"
+authors: ["Mark Dinn"]
+date: 2019-11-11T05:00:00Z
+description: "This is meta description"
+categories: ["Hugo"]
+type: "post"
+---
+
+Are you Developer and recently started your own business and Already made a website to ensure online presence and wants to reach more people. but you are not getting as much as response from your targeted customer or you are unable to reach them. SEO(Search engine optimization)is the cheapest way to reach your customer or client. After 2000 the Internet is more easy access to common people and most of the netizens to find out information search on google/yahoo/bing like a search engine. So if your site ranks at the top of the SERP for your target keywords then sure you will get more valuable traffic to your site and it will help you a lot to grow your business.
+
+Above Paragraph, you see SERP or Keywords that are common SEO Term so Before starting learning SEO let's learn the term used by the SEO expert. It will smoothen your learning journey. Or if you are wishing to hire an SEO guy it will help you his task he/she doing and understand he/she going on the right path. So not making delay let dive…
+
+**Algorithm:** “Algorithm is a process or set of rules to be followed in calculations or other problem-solving operations, especially by a computer.” It is its definition. In SEO we basically mean A very sophisticated and complex program used by the search engine to find out data and indexing it, And when a user gives a data query this program also decides the best result to place in the SERP in order. All search engines use multiple algorithms combination on their data collection and result giving process in different stages.
+
+**Algorithm Change:** All the search engine service providers always try to give the best results to their users. So they always working on updating, refreshing or making and implementing new algorithms. The search engine service provider never revealed the exact date of rolling out any updates or new algorithms to make an effective date. Normally they give a boundary of time like this week or this month, we are going to rolling out a major update or applying new this algorithm. They give this new algorithm a name and they always call it by the given name. Like, google spider, Google panda, etc. Most of the time After one to two week we can see and understand the update or change impact but sometimes it also happens quicker also.
+
+- Algorithm Update: Search Engines regularly making minor changes in their system they normally don’t give an official announcement. But SEO related blogs and journals give the news what the changes made. So Keep update regular visit this industry-related community is important. And when the Major update come You must observe your ranking behavior and if you find you've got the penalty then quickly take necessary step undereating the guidelines given by search engine company.
+
+- Algorithm Refresh: Search engine operator after a regular interval re-run the existing algorithm to find out the new spammer.
+
+- New Algorithm: Improving search quality google and other search engines regularly bringing new algorithms. All new algorithm has its special purpose to serve in the total search engine working process.

--- a/src/content/posts/dummy-2.md
+++ b/src/content/posts/dummy-2.md
@@ -1,0 +1,23 @@
+---
+title: "My awesome second blog post"
+image: "/images/post/post-3.jpg"
+authors: ["Mark Dinn"]
+date: 2019-11-12T05:00:00Z
+description: "This is meta description"
+categories: ["Hugo"]
+type: "post"
+---
+
+Are you Developer and recently started your own business and Already made a website to ensure online presence and wants to reach more people. but you are not getting as much as response from your targeted customer or you are unable to reach them. SEO(Search engine optimization)is the cheapest way to reach your customer or client. After 2000 the Internet is more easy access to common people and most of the netizens to find out information search on google/yahoo/bing like a search engine. So if your site ranks at the top of the SERP for your target keywords then sure you will get more valuable traffic to your site and it will help you a lot to grow your business.
+
+Above Paragraph, you see SERP or Keywords that are common SEO Term so Before starting learning SEO let's learn the term used by the SEO expert. It will smoothen your learning journey. Or if you are wishing to hire an SEO guy it will help you his task he/she doing and understand he/she going on the right path. So not making delay let dive…
+
+**Algorithm:** “Algorithm is a process or set of rules to be followed in calculations or other problem-solving operations, especially by a computer.” It is its definition. In SEO we basically mean A very sophisticated and complex program used by the search engine to find out data and indexing it, And when a user gives a data query this program also decides the best result to place in the SERP in order. All search engines use multiple algorithms combination on their data collection and result giving process in different stages.
+
+**Algorithm Change:** All the search engine service providers always try to give the best results to their users. So they always working on updating, refreshing or making and implementing new algorithms. The search engine service provider never revealed the exact date of rolling out any updates or new algorithms to make an effective date. Normally they give a boundary of time like this week or this month, we are going to rolling out a major update or applying new this algorithm. They give this new algorithm a name and they always call it by the given name. Like, google spider, Google panda, etc. Most of the time After one to two week we can see and understand the update or change impact but sometimes it also happens quicker also.
+
+- Algorithm Update: Search Engines regularly making minor changes in their system they normally don’t give an official announcement. But SEO related blogs and journals give the news what the changes made. So Keep update regular visit this industry-related community is important. And when the Major update come You must observe your ranking behavior and if you find you've got the penalty then quickly take necessary step undereating the guidelines given by search engine company.
+
+- Algorithm Refresh: Search engine operator after a regular interval re-run the existing algorithm to find out the new spammer.
+
+- New Algorithm: Improving search quality google and other search engines regularly bringing new algorithms. All new algorithm has its special purpose to serve in the total search engine working process.

--- a/src/pages/categories/[category].astro
+++ b/src/pages/categories/[category].astro
@@ -34,7 +34,7 @@ const totalPages = Math.ceil(filterByTags.length / pagination);
   <!-- Banner -->
   <section
     class="banner"
-    style="background-image: url('/images/banner/banner-bg.svg'"
+    style="background-image: url('/images/banner/banner-bg.svg')"
   >
     <div class="container">
       <div class="row">

--- a/src/pages/categories/[category]/page/[page].astro
+++ b/src/pages/categories/[category]/page/[page].astro
@@ -4,37 +4,44 @@ import config from "@config/config.json";
 import Base from "@layouts/Base.astro";
 import Pagination from "@layouts/components/Pagination.astro";
 import Post from "@layouts/partials/Post.astro";
-import { getSinglePage } from "@lib/contentParser.astro";
-import { getTaxonomy } from "@lib/taxonomyParser.astro";
 import taxonomyFilter from "@lib/utils/taxonomyFilter";
+import { getSinglePage } from "@lib/contentParser.astro";
+import { sortByDate } from "@lib/utils/sortFunctions";
+import { getTaxonomy } from "@lib/taxonomyParser.astro";
 import { markdownify } from "@lib/utils/textConverter";
 import { getEntryBySlug } from "astro:content";
-const { blog_folder, pagination } = config.settings;
+import type { GetStaticPathsOptions } from "astro";
 
-export async function getStaticPaths() {
-  const { blog_folder } = config.settings;
+export const getStaticPaths = async ({ paginate }: GetStaticPathsOptions) => {
+  const { blog_folder, pagination } = config.settings;
+  const allPosts = await getSinglePage(blog_folder);
+  const sortByDatePosts = sortByDate(allPosts);
+
   const categories = await getTaxonomy(blog_folder, "categories");
-
   return categories.map((category) => {
-    return {
-      params: { category },
-    };
+    const filterByTags = taxonomyFilter(
+      sortByDatePosts,
+      "categories",
+      category
+    );
+    return paginate(filterByTags, {
+      params: { category: category || "" },
+      pageSize: pagination,
+    });
   });
-}
+};
 
-const { category } = Astro.params;
 const homepage = await getEntryBySlug("homepage", "index");
 const { banner } = homepage.data;
-const posts = await getSinglePage(blog_folder);
-const filterByTags = taxonomyFilter(posts, "categories", category);
-const totalPages = Math.ceil(filterByTags.length / pagination);
+const { page } = Astro.props;
+const { category } = Astro.params;
 ---
 
 <Base title={category}>
   <!-- Banner -->
   <section
     class="banner"
-    style="background-image: url('/images/banner/banner-bg.svg'"
+    style="background-image: url('/images/banner/banner-bg.svg')"
   >
     <div class="container">
       <div class="row">
@@ -65,15 +72,11 @@ const totalPages = Math.ceil(filterByTags.length / pagination);
             Posts related to <span class="text-primary">{category}</span> category
           </h1>
           <div class="rounded px-9 py-12 shadow md:p-[60px]">
-            {
-              filterByTags
-                .slice(0, pagination)
-                .map((post) => <Post post={post} />)
-            }
+            {page.data.map((post: any) => <Post post={post} />)}
             <Pagination
               section={`categories/${category}`}
-              currentPage={1}
-              totalPages={totalPages}
+              currentPage={page.currentPage}
+              totalPages={page.lastPage}
             />
           </div>
         </div>


### PR DESCRIPTION
Category pages are not paged correctly.

## Example

https://northendlab-light-astro.vercel.app/categories/hugo
The Pagination of incorrectly links to path `/page/2`.

https://northendlab-light-astro.vercel.app/categories/development-tools
is also the same.

## What I added

`/category/{category}/page/{pageNumber}` to allow paging. Two dummy markdown files have been added to confirm the link.

A preview of the modifications can be found at:
https://northendlab-light-astro-git-fix-categories-paging-retrorocket.vercel.app

Translated with www.DeepL.com/Translator (free version)