### PR TITLE
Posts set to `draft: true` will be built.

### DIFF
--- a/src/lib/contentParser.astro
+++ b/src/lib/contentParser.astro
@@ -4,7 +4,7 @@ import { getCollection } from "astro:content";
 export const getSinglePage = async (collection: any) => {
   const allPage = await getCollection(collection);
   const removeIndex = allPage.filter((data) => data.id !== "_index.md");
-  const removeDrafts = removeIndex.filter((data) => !data.draft);
+  const removeDrafts = removeIndex.filter(({ data }) => !data.draft);
   return removeDrafts;
 };
 ---


### PR DESCRIPTION
`contentParser.astro` is incorrectly filtering using frontmatter.
`draft: true` is not functioning properly.

Please check the official documentation:
https://docs.astro.build/ja/guides/content-collections/#filtering-collection-queries