### PR TITLE
Fix summary overflow issue

### DIFF
--- a/src/layouts/partials/Post.astro
+++ b/src/layouts/partials/Post.astro
@@ -66,7 +66,7 @@ const { post } = Astro.props;
       </ul>
     </li>
   </ul>
-  <p class="text-lg text-text">
+  <p class="text-lg text-text break-words">
     {plainify(post.body?.slice(0, Number(summary_length)))}
   </p>
   <a


### PR DESCRIPTION
The summary style will break when there is long text like url at the beginning of the post.

before:
<img width="1285" alt="Screenshot 2024-12-04 at 10 59 50" src="https://github.com/user-attachments/assets/c9bd2573-220a-4f9e-b5ae-460f6f625be1">

after:
<img width="840" alt="Screenshot 2024-12-04 at 11 00 20" src="https://github.com/user-attachments/assets/6b5fc348-59d4-445d-8d18-be0e6f3c7105">
